### PR TITLE
Force network prefix for pods.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,4 +1,6 @@
+#!/usr/bin/env bash
 set -eu
+
 export LANGUAGE=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8

--- a/master_setup.sh
+++ b/master_setup.sh
@@ -1,7 +1,11 @@
+#!/usr/bin/env bash
 set -eu
 
 hostnamectl set-hostname host0
-kubeadm init --token ${CLUSTER_TOKEN} --apiserver-advertise-address ${IP_ADDRESS} --apiserver-bind-port 8001
+kubeadm init \
+ --token ${CLUSTER_TOKEN} \
+ --apiserver-advertise-address ${IP_ADDRESS} \
+ --apiserver-bind-port 8001 --pod-network-cidr=10.244.0.0/16
 
 export KUBECONFIG="/etc/kubernetes/admin.conf" # Otherwise kubectl won't work.
 


### PR DESCRIPTION
The default Flannel configuration will refuse to work unless this prefix is used.